### PR TITLE
Missing conformer fix

### DIFF
--- a/naglmbis/features/atom.py
+++ b/naglmbis/features/atom.py
@@ -2,7 +2,6 @@ from typing import List, Optional
 
 import torch
 from nagl.features import AtomFeature, one_hot_encode
-
 # from nagl.resonance import enumerate_resonance_forms
 # from nagl.utilities.toolkits import normalize_molecule
 from openeye import oechem

--- a/naglmbis/plugins/plugins.py
+++ b/naglmbis/plugins/plugins.py
@@ -58,6 +58,10 @@ class NAGLMBISHandler(_NonbondedHandler):
             mbis_volumes = volume_model.compute_properties(molecule=ref_mol)[
                 "mbis-volumes"
             ].detach()
+            # qubekit assumes conformers so make one if there are non
+            if ref_mol.n_conformers == 0:
+                ref_mol.generate_conformers(n_conformers=1)
+
             qb_mol = Ligand.from_rdkit(ref_mol.to_rdkit())
             # fix the charges and volumes
             for i in range(qb_mol.n_atoms):

--- a/naglmbis/plugins/plugins.py
+++ b/naglmbis/plugins/plugins.py
@@ -51,6 +51,14 @@ class NAGLMBISHandler(_NonbondedHandler):
             if self.check_charges_assigned(ref_mol, topology):
                 continue
 
+            # qubekit assumes conformers so make one if there are non
+            if ref_mol.n_conformers == 0:
+                ref_mol.generate_conformers(n_conformers=1)
+
+            qb_mol = Ligand.from_rdkit(ref_mol.to_rdkit())
+            # before we run make sure we have enough Rfree terms to run
+            lj.check_element_coverage(molecule=qb_mol)
+
             # predict the mbis charges and volumes
             mbis_charges = charge_model.compute_properties(molecule=ref_mol)[
                 "mbis-charges"
@@ -58,11 +66,7 @@ class NAGLMBISHandler(_NonbondedHandler):
             mbis_volumes = volume_model.compute_properties(molecule=ref_mol)[
                 "mbis-volumes"
             ].detach()
-            # qubekit assumes conformers so make one if there are non
-            if ref_mol.n_conformers == 0:
-                ref_mol.generate_conformers(n_conformers=1)
 
-            qb_mol = Ligand.from_rdkit(ref_mol.to_rdkit())
             # fix the charges and volumes
             for i in range(qb_mol.n_atoms):
                 qb_mol.atoms[i].aim.charge = float(mbis_charges[i][0])

--- a/naglmbis/tests/conftest.py
+++ b/naglmbis/tests/conftest.py
@@ -18,3 +18,17 @@ def water():
     water = Molecule.from_mapped_smiles("[H:2][O:1][H:3]")
     water.generate_conformers(n_conformers=1)
     return water
+
+
+@pytest.fixture()
+def iodobezene():
+    """Make an OpenFF molecule of iodobenzene"""
+    i_ben = Molecule.from_smiles("c1ccc(cc1)I")
+    i_ben.generate_conformers(n_conformers=1)
+    return i_ben
+
+
+@pytest.fixture()
+def methane_no_conf():
+    """Make an OpenFF molecule of methane with no conformer"""
+    return Molecule.from_smiles("C")

--- a/naglmbis/tests/test_plugins.py
+++ b/naglmbis/tests/test_plugins.py
@@ -1,3 +1,4 @@
+import pytest
 from openmm import unit
 
 from naglmbis.plugins import modify_force_field
@@ -63,3 +64,19 @@ def test_plugin_methanol(methanol):
         assert charge / unit.elementary_charge == refs[0]
         assert sigma / unit.nanometers == refs[1]
         assert epsilon / unit.kilojoule_per_mole == refs[2]
+
+
+def test_plugin_missing_element(iodobezene):
+    """Make sure an error is raised when we try to parameterize a molecule with an element not covered by model 1."""
+    from qubekit.utils.exceptions import MissingRfreeError
+
+    nagl_sage = modify_force_field(force_field="openff_unconstrained-2.0.0.offxml")
+    with pytest.raises(MissingRfreeError):
+        _ = nagl_sage.create_openmm_system(topology=iodobezene.to_topology())
+
+
+def test_plugin_no_conformer(methane_no_conf):
+    """Make sure the system can still be made if the refernce molecule has no conformer"""
+
+    nagl_sage = modify_force_field(force_field="openff_unconstrained-2.0.0.offxml")
+    _ = nagl_sage.create_openmm_system(topology=methane_no_conf.to_topology())


### PR DESCRIPTION
This PR fixes an issue with making a QUBEKit molecule from an Openff one with no conformers, here we try to generate one on the fly first.