### PR TITLE
Espaloma style model

### DIFF
--- a/naglmbis/features/atom.py
+++ b/naglmbis/features/atom.py
@@ -284,3 +284,74 @@ class AtomicPolarisability(AtomFeature):
         return torch.Tensor(
             [self._polarisability[atom.atomic_number] for atom in molecule.atoms]
         ).reshape(-1, 1)
+
+
+class Hybridization(AtomFeature):
+    """
+    one hot encode the rdkit hybridization of the atom.
+    """
+
+    _HYBRIDIZATION = [
+        Chem.rdchem.HybridizationType.SP,
+        Chem.rdchem.HybridizationType.SP2,
+        Chem.rdchem.HybridizationType.SP3,
+        Chem.rdchem.HybridizationType.SP3D,
+        Chem.rdchem.HybridizationType.SP3D2,
+        Chem.rdchem.HybridizationType.S,
+    ]
+
+    def __init__(self, hybridization: Optional[List[int]] = None) -> None:
+        self.hybridization = (
+            hybridization if hybridization is not None else [*self._HYBRIDIZATION]
+        )
+
+    def __len__(self):
+        return len(self._HYBRIDIZATION)
+
+    def __call__(self, molecule: Molecule, *args, **kwargs):
+        return torch.vstack(
+            [
+                one_hot_encode(atom.GetHybridization(), self.hybridization)
+                for atom in molecule.to_rdkit().GetAtoms()
+            ]
+        )
+
+
+class TotalValence(AtomFeature):
+    def __len__(self):
+        return 1
+
+    def __call__(self, molecule: Molecule, *args, **kwargs):
+        return torch.Tensor(
+            [[atom.GetTotalValence()] for atom in molecule.to_rdkit().GetAtoms()]
+        )
+
+
+class ExplicitValence(AtomFeature):
+    def __len__(self):
+        return 1
+
+    def __call__(self, molecule: Molecule, *args, **kwargs):
+        return torch.Tensor(
+            [[atom.GetExplicitValence()] for atom in molecule.to_rdkit().GetAtoms()]
+        )
+
+
+class AtomicMass(AtomFeature):
+    def __len__(self):
+        return 1
+
+    def __call__(self, molecule: Molecule, *args, **kwargs):
+        return torch.Tensor(
+            [[atom.GetMass()] for atom in molecule.to_rdkit().GetAtoms()]
+        )
+
+
+class TotalDegree(AtomFeature):
+    def __len__(self):
+        return 1
+
+    def __call__(self, molecule: Molecule, *args, **kwargs):
+        return torch.Tensor(
+            [[atom.GetTotalDegree()] for atom in molecule.to_rdkit().GetAtoms()]
+        )

--- a/naglmbis/models/models.py
+++ b/naglmbis/models/models.py
@@ -1,8 +1,20 @@
 from typing import Literal
 
-from nagl.features import AtomConnectivity, AtomicElement
+from nagl.features import (
+    AtomConnectivity,
+    AtomFormalCharge,
+    AtomicElement,
+    AtomIsAromatic,
+)
 
-from naglmbis.features.atom import AtomInRingOfSize
+from naglmbis.features.atom import (
+    AtomicMass,
+    AtomInRingOfSize,
+    ExplicitValence,
+    Hybridization,
+    TotalDegree,
+    TotalValence,
+)
 from naglmbis.models.base_model import MBISGraphModel
 from naglmbis.utils import get_model_weights
 
@@ -20,6 +32,30 @@ class MBISGraphModelV1(MBISGraphModel):
             AtomInRingOfSize(4),
             AtomInRingOfSize(5),
             AtomInRingOfSize(6),
+        ]
+        bond_features = []
+        return atom_features, bond_features
+
+
+class EspalomaModel(MBISGraphModel):
+    """Try and recreate the espaloma model"""
+
+    def features(self):
+        atom_features = [
+            AtomicElement(["H", "C", "N", "O", "F", "Cl", "Br", "S", "P"]),
+            TotalDegree(),
+            TotalValence(),
+            ExplicitValence(),
+            AtomFormalCharge(),
+            AtomIsAromatic(),
+            AtomicMass(),
+            AtomInRingOfSize(3),
+            AtomInRingOfSize(4),
+            AtomInRingOfSize(5),
+            AtomInRingOfSize(6),
+            AtomInRingOfSize(7),
+            AtomInRingOfSize(8),
+            Hybridization(),
         ]
         bond_features = []
         return atom_features, bond_features

--- a/naglmbis/tests/test_atom_features.py
+++ b/naglmbis/tests/test_atom_features.py
@@ -1,12 +1,18 @@
 import numpy as np
+from nagl.features import AtomConnectivity
 
 from naglmbis.features.atom import (
+    AtomicMass,
     AtomicPolarisability,
+    ExplicitValence,
+    Hybridization,
     HydrogenAtoms,
     LipinskiAcceptor,
     LipinskiDonor,
     PaulingElectronegativity,
     SandersonElectronegativity,
+    TotalDegree,
+    TotalValence,
     vdWRadius,
 )
 
@@ -82,3 +88,62 @@ def test_polarisability(methanol):
     feats = polar(methanol).numpy()
     assert feats.shape == (6, 1)
     assert np.allclose(feats, np.array([[1.76], [1.1], [0.67], [0.67], [0.67], [0.67]]))
+
+
+def test_hybridization(methanol):
+
+    hybrid = Hybridization()
+    assert len(hybrid) == 6
+    feats = hybrid(methanol).numpy()
+    assert feats.shape == (6, 6)
+    assert np.allclose(
+        feats,
+        np.array(
+            [
+                [0, 0, 1, 0, 0, 0],
+                [0, 0, 1, 0, 0, 0],
+                [0, 0, 0, 0, 0, 1],
+                [0, 0, 0, 0, 0, 1],
+                [0, 0, 0, 0, 0, 1],
+                [0, 0, 0, 0, 0, 1],
+            ]
+        ),
+    )
+
+
+def test_total_valence(methanol):
+
+    val = TotalValence()
+    assert len(val) == 1
+    feats = val(methanol).numpy()
+    assert feats.shape == (6, 1)
+    assert np.allclose(feats, np.array([[4], [2], [1], [1], [1], [1]]))
+
+
+def test_explicit_valence(methanol):
+
+    exp = ExplicitValence()
+    assert len(exp) == 1
+    feats = exp(methanol).numpy()
+    assert feats.shape == (6, 1)
+    assert np.allclose(feats, np.array([[4], [2], [1], [1], [1], [1]]))
+
+
+def test_mass(methanol):
+
+    mass = AtomicMass()
+    assert len(mass) == 1
+    feats = mass(methanol).numpy()
+    assert feats.shape == (6, 1)
+    assert np.allclose(
+        feats, np.array([[12.011], [15.999], [1.008], [1.008], [1.008], [1.008]])
+    )
+
+
+def test_degree(methanol):
+
+    degree = TotalDegree()
+    assert len(degree) == 1
+    feats = degree(methanol).numpy()
+    assert feats.shape == (6, 1)
+    assert np.allclose(feats, np.array([[4], [2], [1], [1], [1], [1]]))

--- a/naglmbis/tests/test_models.py
+++ b/naglmbis/tests/test_models.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from naglmbis.models import load_charge_model, load_volume_model
+from naglmbis.models.models import EspalomaModel
 
 
 def test_charge_model_v1(methanol):


### PR DESCRIPTION
This PR adds an espaloma-style model with the same atomic features. One difference is that the formal charge is one hot encoded. The original features can be found [here](https://github.com/choderalab/espaloma/blob/8081037ba937abf1c9999d866e5bd4e4eca278ce/espaloma/graphs/utils/read_homogeneous_graph.py#L62).