### PR TITLE
Rfree model2

### DIFF
--- a/naglmbis/plugins/plugins.py
+++ b/naglmbis/plugins/plugins.py
@@ -30,6 +30,9 @@ class NAGLMBISHandler(_NonbondedHandler):
     _KWARGS = []
     charge_model = ParameterAttribute(default=1, converter=_allow_only([1]))
     volume_model = ParameterAttribute(default=1, converter=_allow_only([1]))
+    rfree_model = ParameterAttribute(
+        default=1, converter=_allow_only(list(trained_models.keys()))
+    )
 
     def check_handler_compatibility(self, handler_kwargs):
         """We do not want to be mixed with AM1 handler as this is not compatible."""
@@ -40,7 +43,7 @@ class NAGLMBISHandler(_NonbondedHandler):
         charge_model = load_charge_model(charge_model=self.charge_model)
         volume_model = load_volume_model(volume_model=self.volume_model)
         # the volume and charge models are tied to the trained model
-        lj = trained_models[self.volume_model]
+        lj = trained_models[self.rfree_model]
 
         force = super().create_force(system, topology, **kwargs)
 

--- a/naglmbis/plugins/trained_models.py
+++ b/naglmbis/plugins/trained_models.py
@@ -27,4 +27,22 @@ model_v1 = LennardJones612(
     beta=0.479,
 )
 
-trained_models = {1: model_v1}
+# A second model trained on Mixture parameters against tip4pfb water
+model_v1_mixture = LennardJones612(
+    free_parameters={
+        "H": h_base(r_free=1.887),
+        "C": c_base(r_free=2.058),
+        "N": n_base(r_free=1.631),
+        "O": o_base(r_free=1.659),
+        "X": h_base(r_free=0.978),
+        "Cl": cl_base(r_free=1.868),
+        "S": s_base(r_free=1.841),
+        "F": f_base(r_free=1.644),
+        "Br": br_base(r_free=1.932),
+    },
+    alpha=1.216,
+    beta=0.487,
+)
+
+
+trained_models = {1: model_v1, 2: model_v1_mixture}


### PR DESCRIPTION
This PR adds a new set of Rfree parameters which were trained using mixtures with openff-evaluator. The mixtures included water modelled with tip4p-fb and the parameters should be used with only this model.

