### PR TITLE
Esploma charge support

### DIFF
--- a/devtools/conda-envs/env.yaml
+++ b/devtools/conda-envs/env.yaml
@@ -16,5 +16,7 @@ dependencies:
   - openff-toolkit <0.11.0, >=0.10.6
   - qubekit
   - pytorch-lightning
-  - dgl >=0.7
+  - dgl <1.0.0, >=0.7
   - openff-utilities <=0.1.3
+  - pip:
+      - espaloma_charge

--- a/naglmbis/models/models.py
+++ b/naglmbis/models/models.py
@@ -61,10 +61,14 @@ class EspalomaModel(MBISGraphModel):
         return atom_features, bond_features
 
 
-charge_weights = {1: {"path": "mbis_charges_v1.ckpt", "model": MBISGraphModelV1}}
-volume_weights = {1: {"path": "mbis_volumes_v1.ckpt", "model": MBISGraphModelV1}}
-CHARGE_MODELS = Literal[1]
-VOLUME_MODELS = Literal[1]
+charge_weights = {
+    "nagl-v1": {"path": "mbis_charges_v1.ckpt", "model": MBISGraphModelV1}
+}
+volume_weights = {
+    "nagl-v1": {"path": "mbis_volumes_v1.ckpt", "model": MBISGraphModelV1}
+}
+CHARGE_MODELS = Literal["nagl-v1"]
+VOLUME_MODELS = Literal["nagl-v1"]
 
 
 def load_charge_model(charge_model: CHARGE_MODELS) -> MBISGraphModel:

--- a/naglmbis/plugins/trained_models.py
+++ b/naglmbis/plugins/trained_models.py
@@ -44,5 +44,42 @@ model_v1_mixture = LennardJones612(
     beta=0.487,
 )
 
+# A model optimised with Mixture properties against tip4p-fb using espaloma-charge-0.0.8
+model_v1_espaloma_mixture = LennardJones612(
+    free_parameters={
+        "H": h_base(r_free=1.925),
+        "C": c_base(r_free=2.013),
+        "N": n_base(r_free=1.807),
+        "O": o_base(r_free=1.537),
+        "X": h_base(r_free=1.256),
+        "Cl": cl_base(r_free=1.866),
+        "S": s_base(r_free=1.812),
+        "F": f_base(r_free=1.627),
+        "Br": br_base(r_free=1.969),
+    },
+    alpha=1.2,
+    beta=0.502,
+)
 
-trained_models = {1: model_v1, 2: model_v1_mixture}
+model_v2_espaloma_mixture_no_polar_h = LennardJones612(
+    free_parameters={
+        "H": h_base(r_free=1.868),
+        "C": c_base(r_free=2.022),
+        "N": n_base(r_free=1.835),
+        "O": o_base(r_free=1.603),
+        "Cl": cl_base(r_free=1.846),
+        "S": s_base(r_free=1.810),
+        "F": f_base(r_free=1.566),
+        "Br": br_base(r_free=1.930),
+    },
+    lj_on_polar_h=False,
+    alpha=1.129,
+    beta=0.555,
+)
+
+trained_models = {
+    1: model_v1,
+    2: model_v1_mixture,
+    "espaloma-v1": model_v1_espaloma_mixture,
+    "espaloma-v2": model_v2_espaloma_mixture_no_polar_h,
+}

--- a/naglmbis/tests/test_atom_features.py
+++ b/naglmbis/tests/test_atom_features.py
@@ -82,7 +82,6 @@ def test_vdw_radii(methanol):
 
 
 def test_polarisability(methanol):
-
     polar = AtomicPolarisability()
     assert len(polar) == 1
     feats = polar(methanol).numpy()
@@ -91,7 +90,6 @@ def test_polarisability(methanol):
 
 
 def test_hybridization(methanol):
-
     hybrid = Hybridization()
     assert len(hybrid) == 6
     feats = hybrid(methanol).numpy()
@@ -112,7 +110,6 @@ def test_hybridization(methanol):
 
 
 def test_total_valence(methanol):
-
     val = TotalValence()
     assert len(val) == 1
     feats = val(methanol).numpy()
@@ -121,7 +118,6 @@ def test_total_valence(methanol):
 
 
 def test_explicit_valence(methanol):
-
     exp = ExplicitValence()
     assert len(exp) == 1
     feats = exp(methanol).numpy()
@@ -130,7 +126,6 @@ def test_explicit_valence(methanol):
 
 
 def test_mass(methanol):
-
     mass = AtomicMass()
     assert len(mass) == 1
     feats = mass(methanol).numpy()
@@ -141,7 +136,6 @@ def test_mass(methanol):
 
 
 def test_degree(methanol):
-
     degree = TotalDegree()
     assert len(degree) == 1
     feats = degree(methanol).numpy()

--- a/naglmbis/tests/test_models.py
+++ b/naglmbis/tests/test_models.py
@@ -7,7 +7,7 @@ def test_charge_model_v1(methanol):
     """
     Test loading the charge model and computing the MBIS charges.
     """
-    charge_model = load_charge_model(charge_model=1)
+    charge_model = load_charge_model(charge_model="nagl-v1")
     charges = charge_model.compute_properties(molecule=methanol)[
         "mbis-charges"
     ].detach()
@@ -19,7 +19,7 @@ def test_volume_model_v1(methanol):
     """
     Test loading the volume model and computing the MBIS volumes
     """
-    volume_model = load_volume_model(volume_model=1)
+    volume_model = load_volume_model(volume_model="nagl-v1")
     volumes = volume_model.compute_properties(molecule=methanol)[
         "mbis-volumes"
     ].detach()


### PR DESCRIPTION
This PR adds support to use charges predicted using [espaloma-charge](https://github.com/choderalab/espaloma_charge) in combination with LJ parameters based on NAGL predicted volumes. Rfree parameters fit with this model against mixture properties with openff-evaluator and tip4p-fb are included and the charge and volume models have been renamed to distinguish between espaloma and nagl predicted values.  