### PR TITLE
Support QUBEKit fit BCCs

### DIFF
--- a/devtools/conda-envs/env.yaml
+++ b/devtools/conda-envs/env.yaml
@@ -13,10 +13,13 @@ dependencies:
 
   # core deps
   - nagl
-  - openff-toolkit <0.11.0, >=0.10.6
-  - qubekit
+  - openff-toolkit-base <0.11.0, >=0.10.6
+  - qcengine >=0.18.0
+  - jinja2
+  # - qubekit
   - pytorch-lightning
   - dgl <1.0.0, >=0.7
   - openff-utilities <=0.1.3
   - pip:
       - espaloma_charge
+      - git+https://github.com/qubekit/QUBEKit.git

--- a/devtools/conda-envs/env.yaml
+++ b/devtools/conda-envs/env.yaml
@@ -17,6 +17,7 @@ dependencies:
   - qcengine >=0.18.0
   - jinja2
   - chemper
+  - torsiondrive
   # - qubekit
   - pytorch-lightning
   - dgl <1.0.0, >=0.7

--- a/devtools/conda-envs/env.yaml
+++ b/devtools/conda-envs/env.yaml
@@ -16,6 +16,7 @@ dependencies:
   - openff-toolkit-base <0.11.0, >=0.10.6
   - qcengine >=0.18.0
   - jinja2
+  - chemper
   # - qubekit
   - pytorch-lightning
   - dgl <1.0.0, >=0.7

--- a/naglmbis/plugins/bccs.py
+++ b/naglmbis/plugins/bccs.py
@@ -1,0 +1,45 @@
+# a file to track bcc models
+from typing_extensions import Literal
+from openff.toolkit.typing.engines.smirnoff import ForceField
+
+# Model fit with nagl-v1 charges and nagl-v1 volumes with no polar h Rfree
+# list of smirks and charge corrections
+bcc_model_v1 = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <BondChargeCorrection version="0.3">
+        <BCC smirks="[#1:1]-[#6a:2]" charge_correction="1.918287613579e-04 * elementary_charge" id="bcc-0" />
+        <BCC smirks="[#6a:1]:[#7X2a:2]" charge_correction="-6.515627555745e-02 * elementary_charge" id="bcc-1" />
+        <BCC smirks="[#6a:1]-[$([NX3](=O)=O),$([NX3+](=O)[O-]):2]" charge_correction="0 * elementary_charge" id="bcc-2"/>
+        <BCC smirks="[#6a:1]-[NX3;H2;!$(NC=O):2]" charge_correction="-3.287530301247e-03 * elementary_charge" id="bcc-3" />
+        <BCC smirks="[#1:1]-[NX3;H2;!$(NC=O):2]-[#6a]" charge_correction="-2.385134696800e-02 * elementary_charge" id="bcc-4" />
+        <BCC smirks="[#6a:1]-[#9:2]" charge_correction="4.111091863251e-02 * elementary_charge" id="bcc-5" />
+        <BCC smirks="[#6a:1]-[#35:2]" charge_correction="0 * elementary_charge" id="bcc-6"/>
+        <BCC smirks="[#6a]-[#6X2:1]#[#7X1:2]" charge_correction="0 * elementary_charge" id="bcc-7"/>
+        <BCC smirks="[#6a:1]-[#8X2H1:2]" charge_correction="0 * elementary_charge" id="bcc-8"/>
+        <BCC smirks="[#8X1H0:1]=[#16:2]" charge_correction="1.194201883302e-01 * elementary_charge" id="bcc-9" />
+        <BCC smirks="[#6!a:1]-[#8X2H1:2]" charge_correction="-4.327420532297e-02 * elementary_charge" id="bcc-10" />
+        <BCC smirks="[$([#6X3!a](C)(C)),$([#6X3H1!a](C)):1]=[#8X1H0:2]" charge_correction="-1.226504648139e-01 * elementary_charge" id="bcc-11" />
+        <BCC smirks="[#6!a:1]-[#16X2H0:2]" charge_correction="-7.065983295162e-02 * elementary_charge" id="bcc-12" />
+        <BCC smirks="[#6!a:1]-[#16X2H1:2]" charge_correction="0 * elementary_charge" id="bcc-13"/>
+        <BCC smirks="[$([NX3](=O)=O),$([NX3+](=O)[O-]):1]-,=[#8X1:2]" charge_correction="0 * elementary_charge" id="bcc-14"/>
+        <BCC smirks="[#6!a:1]-[#17:2]" charge_correction="7.067734595593e-03 * elementary_charge" id="bcc-15" />
+        <BCC smirks="[#6!a:1]-[#35:2]" charge_correction="-3.473056879281e-02 * elementary_charge" id="bcc-16" />
+        <BCC smirks="[#6!a:1]-[NX3;H2;!$(NC=O):2]" charge_correction="0 * elementary_charge" id="bcc-17"/>
+        <BCC smirks="[*!a]-[#6X2:1]#[#7X1:2]" charge_correction="0 * elementary_charge" id="bcc-18"/>
+    </BondChargeCorrection>
+</SMIRNOFF>
+"""
+
+BCC_MODELS = Literal["nagl-v1"]
+bcc_force_fields = {"nagl-v1": bcc_model_v1}
+
+
+def load_bcc_model(bcc_model: BCC_MODELS):
+    """
+    Load the BCC parameter handler with the requested model.
+
+    Return:
+        The BCC plugin parameter handler from qubekit which can be used to get matches
+    """
+    ff = ForceField(bcc_force_fields[bcc_model], load_plugins=True)
+    return ff.get_parameter_handler("BondChargeCorrection")

--- a/naglmbis/plugins/trained_models.py
+++ b/naglmbis/plugins/trained_models.py
@@ -44,6 +44,23 @@ model_v1_mixture = LennardJones612(
     beta=0.487,
 )
 
+# Trained on mixture properties with tip4p-fb and bccs using nagl charge and volume v1 no polar h
+model_v1_mixture_no_polar_bcc = LennardJones612(
+    free_parameters={
+        "H": h_base(r_free=1.825),
+        "C": c_base(r_free=2.059),
+        "N": n_base(r_free=1.636),
+        "O": o_base(r_free=1.707),
+        "Cl": cl_base(r_free=1.877),
+        "S": s_base(r_free=1.811),
+        "F": f_base(r_free=1.637),
+        "Br": br_base(r_free=1.917),
+    },
+    lj_on_polar_h=False,
+    alpha=1.165,
+    beta=0.476,
+)
+
 # A model optimised with Mixture properties against tip4p-fb using espaloma-charge-0.0.8
 model_v1_espaloma_mixture = LennardJones612(
     free_parameters={
@@ -80,6 +97,7 @@ model_v2_espaloma_mixture_no_polar_h = LennardJones612(
 trained_models = {
     1: model_v1,
     2: model_v1_mixture,
+    3: model_v1_mixture_no_polar_bcc,
     "espaloma-v1": model_v1_espaloma_mixture,
     "espaloma-v2": model_v2_espaloma_mixture_no_polar_h,
 }

--- a/naglmbis/tests/test_plugins.py
+++ b/naglmbis/tests/test_plugins.py
@@ -117,3 +117,38 @@ def test_espaloma_charge(methanol, tmpdir):
             assert charge / unit.elementary_charge == pytest.approx(refs[0], abs=1e-5)
             assert sigma / unit.nanometers == pytest.approx(refs[1])
             assert epsilon / unit.kilojoule_per_mole == pytest.approx(refs[2])
+
+
+def test_bcc_charges(methanol):
+    """
+    Make sure bccs are correctly apply with NAGL charges when requested.
+
+    This is the same as the test_plugin_methanol test but the carbon and oxygen charges are slightly different
+    """
+    nagl_sage = modify_force_field(force_field="openff_unconstrained-2.0.0.offxml")
+    nagl_handler = nagl_sage.get_parameter_handler("NAGLMBIS")
+    nagl_handler.bcc_model = "nagl-v1"
+    methanol_system = nagl_sage.create_openmm_system(topology=methanol.to_topology())
+    methanol_forces = {
+        methanol_system.getForce(index).__class__.__name__: methanol_system.getForce(
+            index
+        )
+        for index in range(methanol_system.getNumForces())
+    }
+    # check the system parameters
+    ref_parameters = {
+        # index: [charge, sigma, epsilon]
+        0: [0.041475, 0.3506905398376649, 0.29246740950730743],
+        1: [-0.628155, 0.30824716826324094, 0.42874612945325397],
+        2: [0.049413, 0.23126852234757847, 0.07259909774155628],
+        3: [0.049413, 0.23126852234757847, 0.07259909774155628],
+        4: [0.049413, 0.23126852234757847, 0.07259909774155628],
+        5: [0.438441, 0.11098246898497655, 0.41631660852994784],
+    }
+    for particle_index, refs in ref_parameters.items():
+        charge, sigma, epsilon = methanol_forces[
+            "NonbondedForce"
+        ].getParticleParameters(particle_index)
+        assert charge / unit.elementary_charge == pytest.approx(refs[0], abs=1e-5)
+        assert sigma / unit.nanometers == pytest.approx(refs[1])
+        assert epsilon / unit.kilojoule_per_mole == pytest.approx(refs[2])


### PR DESCRIPTION
This PR adds support for QUBEKit plugin BCCs which can be applied ontop of NAGL charge predictions. This also includes the Rfree parameters for models fit to mixtures properties with tip4p-fb. 